### PR TITLE
Clean up flux interfaces

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,12 +1,11 @@
 flutter_flux Example
-================
+====================
 
 To run the example, follow the instructions at [flutter.io](https://flutter.io)
 for setting up a flutter environment and connecting your Android or iOS device.
 
 Then do this:
 
-1. cd chat_app
+1. `cd chat_app`
 2. `pub get`
-3. flutter run [--ios]
-
+3. `flutter run`

--- a/example/chat_app/lib/main.dart
+++ b/example/chat_app/lib/main.dart
@@ -9,7 +9,7 @@ import 'stores.dart';
 
 void main() {
   runApp(new MaterialApp(
-      title: "Firechat",
+      title: 'Chat',
       theme: new ThemeData(
           primarySwatch: Colors.purple, accentColor: Colors.orangeAccent[400]),
       home: new ChatScreen()));
@@ -19,7 +19,7 @@ class ChatScreen extends StoreWatcher {
   ChatScreen({Key key}) : super(key: key);
 
   @override
-  void initState(ListenToStore listenToStore) {
+  void initStores(ListenToStore listenToStore) {
     listenToStore(messageStoreToken);
     listenToStore(userStoreToken);
   }
@@ -57,7 +57,7 @@ class ChatScreen extends StoreWatcher {
 
     return new Scaffold(
         appBar:
-            new AppBar(title: new Text("Chatting as ${chatUserStore.me.name}")),
+            new AppBar(title: new Text('Chatting as ${chatUserStore.me.name}')),
         body: new Column(children: <Widget>[
           new Flexible(
               child: new Block(

--- a/lib/flutter_flux.dart
+++ b/lib/flutter_flux.dart
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// The w_flux library implements a uni-directional data flow pattern comprised
-/// of [Action]s, [Store]s, and [FluxComponent]s.
+/// The flutter_flux library implements a unidirectional data flow pattern
+/// comprised of [Action]s, [Store]s, and [StoreWatcher]s.
 ///
 /// - [Action]s initiate mutation of app data that resides in [Store]s.
-/// - Data mutations within [Store]s trigger re-rendering of app view (defined
-///   in [FluxComponent]s).
-/// - [FluxComponent]s dispatch [Action]s in response to user interaction.
+/// - Data mutations within [Store]s trigger re-rendering of a widget (defined
+///   in [StoreWatcher]s).
+/// - [StoreWatcher]s dispatch [Action]s in response to user interaction.
 
 export 'src/action.dart';
 export 'src/store.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,25 +1,19 @@
 name: flutter_flux
-version: 3.0.0
-description: Flux library for Flutter, featuring uni-directional dataflow
-  inspired by reflux and Facebook's flux architecture.
-  This is an experimental package and does not have official support for the
-  Flutter team. However, feedback is most welcome!
-  # Based on https://github.com/Workiva/w_flux.
-authors:
-  - Workiva Client Platform Team <team-clientplatform@workiva.com>
-  - Dustin Lessard <dustin.lessard@workiva.com>
-  - Evan Weible <evan.weible@workiva.com>
-  - Jay Udey <jay.udey@workiva.com>
-  - Max Peterson <maxwell.peterson@workiva.com>
-  - Trent Grover <trent.grover@workiva.com>
-  - Jim Beveridge <jimbe@google.com>
+version: 4.0.0
+description: Flux library for Flutter, featuring unidirectional dataflow inspired by reflux and Facebook's flux architecture.
 homepage: https://github.com/flutter/flutter_flux
+dependencies:
+  meta: ^1.0.3
+  #flutter:
+  #  sdk: flutter
+
 dev_dependencies:
-  # flutter must be a dev_dependency, otherwise pub gives this error message:
-  # Invalid description: "../flutter/packages/flutter" is a relative path,
-  # but this isn't a local pubspec.
+  # TODO(abarth): Remove this in favor of the SDK source above.
   flutter:
     path: ../flutter/packages/flutter
-  quiver:  "^0.22.0"
+  quiver:  ^0.22.0
   rate_limit: ^0.1.0
-  test: "^0.12.13"
+  test: ^0.12.13
+
+environment:
+  sdk: ^1.19.0


### PR DESCRIPTION
- Rather than using complex mixin inheritance, we now use composition for
  StoreListener.
- Rename StoreWatcher.initState to StoreWatcher.initStores to suggest that
  this function is for initializing the stores rather than initializing the
  (hidden) state object.
- Update the dartdocs to reflect how the code works currently.
