### PR TITLE
Switch to using SDK source

### DIFF
--- a/example/chat_app/lib/main.dart
+++ b/example/chat_app/lib/main.dart
@@ -82,16 +82,26 @@ class ChatMessageListItem extends StatefulWidget {
   State createState() => new ChatMessageListItemState();
 }
 
-class ChatMessageListItemState extends State<ChatMessageListItem> {
-  ChatMessageListItemState() {
+class ChatMessageListItemState extends State<ChatMessageListItem>
+    with SingleTickerProviderStateMixin {
+  AnimationController _animationController;
+  Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = new AnimationController(
+        vsync: this, duration: new Duration(milliseconds: 700));
     _animation = new CurvedAnimation(
         parent: _animationController, curve: Curves.easeOut);
     _animationController.forward();
   }
 
-  AnimationController _animationController =
-      new AnimationController(duration: new Duration(milliseconds: 700));
-  Animation<double> _animation;
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -106,11 +116,5 @@ class ChatMessageListItemState extends State<ChatMessageListItem> {
                 backgroundColor: message.sender.color),
             title: new Text(message.sender.name),
             subtitle: new Text(message.text)));
-  }
-
-  @override
-  void dispose() {
-    _animationController.dispose();
-    super.dispose();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,10 @@ description: Flux library for Flutter, featuring unidirectional dataflow inspire
 homepage: https://github.com/flutter/flutter_flux
 dependencies:
   meta: ^1.0.3
-  #flutter:
-  #  sdk: flutter
+  flutter:
+   sdk: flutter
 
 dev_dependencies:
-  # TODO(abarth): Remove this in favor of the SDK source above.
-  flutter:
-    path: ../flutter/packages/flutter
   quiver:  ^0.22.0
   rate_limit: ^0.1.0
   test: ^0.12.13

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -13,7 +13,7 @@ which dart
 echo "Using Dart version:"
 dart --version
 
-pub get
+../flutter/bin/flutter packages get
 
 echo "Analyzing the extracted Dart libraries."
 


### PR DESCRIPTION
After this patch, we now depend on package:flutter using an SDK source, which
means package:flutter doesn't need to be at a particular path relative to this
package anymore.
