### PR TITLE
Remove unnecessary step to run the app

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -7,5 +7,4 @@ for setting up a flutter environment and connecting your Android or iOS device.
 Then do this:
 
 1. `cd chat_app`
-2. `pub get`
-3. `flutter run`
+2. `flutter run`


### PR DESCRIPTION
Apparently "flutter run" includes the "pub get" step.

chat_app [master]$ flutter run
Running 'flutter packages get' in chat_app... 2419ms
New users installing Flutter won't necessarily know about the "pub" tool, so removing it will reduce friction for those users.