### PR TITLE
Fix build errors with Flutter beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,23 +102,6 @@ class RandomColorStore extends Store {
     trigger();
   }
 }
-```
-
-**BONUS:** `Stores` can be initialized with a stream transformer to modify the standard behavior of the `trigger` stream.
-This can be useful for throttling UI rendering in response to high frequency `Store` mutations.
-
-```dart
-import 'package:rate_limit/rate_limit.dart';
-import 'package:flutter_flux/flutter_flux.dart';
-
-class ThrottledStore extends Store {
-  ...
-
-  ThrottledStore(this._actions) : super.withTransformer(new Throttler(const Duration(milliseconds: 30))) {
-    ...
-  }
-}
-```
 
 **BONUS:** `Stores` provide an optional terse syntax for action -> data mutation -> trigger operations.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+# This file is required to fix the "flutter analyze" error that says:
+# mixin_inherits_from_not_object
+analyzer:
+  language:
+    enableSuperMixins: true
+    enableAssertInitializer: true

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,8 +58,11 @@ class ChatScreenState extends State<ChatScreen>
     chatUserStore = listenToStore(userStoreToken);
   }
 
-  void handleChatMessageStoreChanged(ChatMessageStore messageStore) {
-    msgController.text = messageStore.currentMessage;
+  void handleChatMessageStoreChanged(Store store) {
+    ChatMessageStore messageStore = store;
+    if (messageStore.currentMessage.isEmpty) {
+        msgController.clear();
+    }
     setState(() {});
   }
 

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -14,7 +14,7 @@
 
 import 'dart:async';
 
-typedef void OnData(dynamic event);
+typedef void OnData<T>(T event);
 
 /// A command that can be dispatched and listened to.
 ///
@@ -42,7 +42,7 @@ typedef void OnData(dynamic event);
 /// action.
 ///
 class Action<T> implements Function {
-  List<OnData> _listeners = <OnData>[];
+  List<OnData<T>> _listeners = <OnData<T>>[];
 
   /// Dispatch this [Action] to all listeners. If a payload is supplied, it will
   /// be passed to each listener's callback, otherwise null will be passed.
@@ -60,7 +60,7 @@ class Action<T> implements Function {
     // for stream-based actions vs. 0.14 ms for this action implementation.
     return Future.wait<dynamic>(
       _listeners.map(
-        (OnData l) => new Future<dynamic>.microtask(() => l(payload))
+        (OnData<T> l) => new Future<dynamic>.microtask(() => l(payload))
       ),
     );
   }
@@ -74,7 +74,7 @@ class Action<T> implements Function {
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
-  ActionSubscription listen(OnData onData) {
+  ActionSubscription listen(OnData<T> onData) {
     _listeners.add(onData);
     return new ActionSubscription(() => _listeners.remove(onData));
   }

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -77,16 +77,12 @@ class Store {
   }
 
   /// A convenience method for listening to an [action] and triggering
-  /// automatically once the callback for said action has completed.
-  ///
-  /// If [onAction] is provided, it will be called every time [action] is
-  /// dispatched. If [onAction] returns a [Future], [trigger] will not be
-  /// called until that future has resolved and the function returns either
-  /// void (null) or true.
-  void triggerOnAction(Action<dynamic> action,
-      [dynamic onAction(dynamic payload)]) {
+  /// automatically. The callback doesn't call return, so the return
+  /// type of onAction is null.
+  void triggerOnAction<T>(Action<T> action,
+      [dynamic onAction(T payload)]) {
     if (onAction != null) {
-      action.listen((dynamic payload) async {
+      action.listen((T payload) async {
         await onAction(payload);
         trigger();
       });
@@ -104,8 +100,8 @@ class Store {
   /// If [onAction] returns a [Future], [trigger] will not be
   /// called until that future has resolved and the function returns either
   /// void (null) or true.
-  void triggerOnConditionalAction(
-      Action<dynamic> action, bool onAction(dynamic payload)) {
+  void triggerOnConditionalAction<T>(
+      Action<T> action, bool onAction(T payload)) {
     assert(action != null);
     action.listen((dynamic payload) async {
       // Action functions must return bool, or a Future<bool>.
@@ -116,7 +112,7 @@ class Store {
       } else {
         wasChanged = result;
       }
-      if (wasChanged == true) {
+      if (wasChanged) {
         trigger();
       }
     });

--- a/lib/src/store_watcher.dart
+++ b/lib/src/store_watcher.dart
@@ -79,7 +79,7 @@ class StoreWatcherState extends State<StoreWatcher> with StoreWatcherMixin<Store
 /// Listens to changes in a number of different stores.
 ///
 /// Used by [StoreWatcher] to track which stores the widget is listening to.
-abstract class StoreWatcherMixin<T extends StatefulWidget> implements State<T>{
+abstract class StoreWatcherMixin<T extends StatefulWidget> extends State<T>{
   final Map<Store, StreamSubscription<Store>> _streamSubscriptions = <Store, StreamSubscription<Store>>{};
 
   /// Start receiving notifications from the given store, optionally routed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 # Important: Use "flutter packages get", not "pub get".
 name: flutter_flux
 author: Flutter Authors <flutter-dev@googlegroups.com>
-version: 4.0.1
+version: 4.1.0
 description: Flux library for Flutter, featuring unidirectional dataflow inspired by reflux and Facebook's flux architecture.
-homepage: https://github.com/flutter/flutter_flux
+homepage: https://github.com/google/flutter_flux
 dependencies:
   meta: ^1.0.3
   flutter:
@@ -11,7 +11,6 @@ dependencies:
 
 dev_dependencies:
   quiver:  ">=0.24.0 <1.0.0"
-  rate_limit: ^0.1.0
   test: ^0.12.13
   flutter_test:
     sdk: flutter

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -18,7 +18,6 @@ import 'dart:async';
 import 'package:flutter_flux/src/action.dart';
 import 'package:flutter_flux/src/store.dart';
 import 'package:quiver/testing/async.dart';
-import 'package:rate_limit/rate_limit.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -42,34 +41,6 @@ void main() {
       }));
 
       store.trigger();
-    });
-
-    test('should support stream transforms', () {
-      new FakeAsync().run((FakeAsync async) {
-        // ensure that multiple trigger executions emit
-        // exactly 2 throttled triggers to external listeners
-        // (1 for the initial trigger and 1 as the aggregate of
-        // all others that occurred within the throttled duration)
-        int count = 0;
-        store = new Store.withTransformer(
-            new Throttler<Store>(const Duration(milliseconds: 30)));
-        store.listen((Store listenedStore) {
-          count++;
-        });
-
-        store.trigger();
-        store.trigger();
-        store.trigger();
-        store.trigger();
-        store.trigger();
-        async.elapse(new Duration(milliseconds: 20));
-        expect(count, equals(1));
-        async.elapse(new Duration(milliseconds: 30));
-        expect(count, equals(2));
-        // Make sure that there aren't any queued up.
-        async.elapse(new Duration(milliseconds: 500));
-        expect(count, equals(2));
-      });
     });
 
     test('should trigger in response to an action', () {


### PR DESCRIPTION
Fixed in the library:
- Error: A value of type '(dart.core::String) → dart.core::Null'
  can't be assigned to a variable of type '(dynamic) → dynamic'.
- Version in pubspec.yaml needs to be bumped.
- Error from `flutter analyze`: fix mixin_inherits_from_not_object.
  (Added analysis_options.)

Fixed in example:
- Text editor for the message was broken because insert cursor was at
  the wrong position.

Finally, removed ThrottledStore from README and test - it's not used.
