### PR TITLE
Created ActionWatcherMixin, which auto unsubscribe widget from actions when is it disposed.

### DIFF
--- a/lib/src/action_watcher.dart
+++ b/lib/src/action_watcher.dart
@@ -1,0 +1,49 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_flux/flutter_flux.dart';
+
+/// Listens to changes in a number of different actions.
+/// Used by to track which actions the widget is listening and to usubscribe from him when disposed.
+mixin ActionWatcherMixin<T extends StatefulWidget> on State<T> {
+  final Map<Action, ActionSubscription> _actionsSubscriptions =
+      <Action, ActionSubscription>{};
+
+  /// Stop receiving notifications from the given action.
+  @protected
+  void unlistenFromAction(Action actionToUnsusbscribe) {
+    _actionsSubscriptions.forEach((actionReference, subscription) {
+      if (actionReference == actionToUnsusbscribe) {
+        subscription.cancel();
+      }
+    });
+  }
+
+  /// Listen to a given action and automatically cancel subscriptions when widget is disposed
+  @protected
+  void listenToAction(Action action, OnData onData) {
+    _actionsSubscriptions.addAll({action: action.listen(onData)});
+  }
+
+  /// Cancel all actions listen (subscriptions).
+  @override
+  void dispose() {
+    final Iterable<ActionSubscription> actionSubscriptions =
+        _actionsSubscriptions.values;
+    for (final ActionSubscription actionSubscription in actionSubscriptions)
+      actionSubscription.cancel();
+  }
+}

--- a/lib/src/store_watcher.dart
+++ b/lib/src/store_watcher.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
 import 'store.dart';
+import 'action_watcher.dart';
 
 /// Signature for a function the lets the caller listen to a store.
 typedef Store ListenToStore(StoreToken token, [ValueChanged<Store> onStoreChanged]);
@@ -47,7 +48,8 @@ abstract class StoreWatcher extends StatefulWidget {
 }
 
 /// State for a [StoreWatcher] widget.
-class StoreWatcherState extends State<StoreWatcher> with StoreWatcherMixin<StoreWatcher> {
+class StoreWatcherState extends State<StoreWatcher> 
+  with StoreWatcherMixin<StoreWatcher>, ActionWatcherMixin<StoreWatcher>{
 
   final Map<StoreToken, Store> _storeTokens = <StoreToken, Store>{};
 


### PR DESCRIPTION
This corrects a common scenario like:
When listening to an action on a page A that pushes the navigator to another page B, when page B overlaps page A the developer is obliged to unsubscribe from all actions in which he used the listen function, generating an ugly code, like spagheti .
With this approach the developer only needs to use the following function within page A that elá will perform the automatic unsubscribe when executing the dispose.
````dart
//my widget definition...
  @override
  void initState() {
    listenToAction(action, (_) { }); // automatically cancel subscription on dispose page
  }
//...
````
im using a mixin in my project while this pull isn't aprooved...