### PR TITLE
removed unused dart:async

### DIFF
--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 typedef void OnData<T>(T event);
 
 /// A command that can be dispatched and listened to.
@@ -60,8 +58,7 @@ class Action<T> implements Function {
     // for stream-based actions vs. 0.14 ms for this action implementation.
     return Future.wait<dynamic>(
       _listeners.map(
-        (OnData<T> l) => new Future<dynamic>.microtask(() => l(payload))
-      ),
+          (OnData<T> l) => new Future<dynamic>.microtask(() => l(payload))),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,4 +18,4 @@ dev_dependencies:
   
 
 environment:
-  sdk: ">=1.24.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"


### PR DESCRIPTION
removed unused dart:async as Future and Streams are implemented in dart:core as per Dart 2.1